### PR TITLE
#159620120 Make slug be the unique identifier for article

### DIFF
--- a/authors/apps/articles/serializers.py
+++ b/authors/apps/articles/serializers.py
@@ -1,17 +1,9 @@
 from rest_framework import serializers
-from rest_framework.validators import UniqueValidator
 
 from .models import Article
 
 
 class ArticleSerializer(serializers.ModelSerializer):
-    slug = serializers.CharField(
-        max_length=100,
-        validators=[UniqueValidator(
-            queryset=Article.objects.all(),
-            message="Title already exists, please enter a different Title")],
-    )
-
     title = serializers.CharField(
         required=True,
         max_length=100,
@@ -20,6 +12,7 @@ class ArticleSerializer(serializers.ModelSerializer):
     class Meta:
         model = Article
         fields = '__all__'
+        lookup_url_kwarg = 'slug'
 
     def create(self, validated_data):
         return super().create(validated_data)

--- a/authors/apps/articles/tests/test_views.py
+++ b/authors/apps/articles/tests/test_views.py
@@ -63,10 +63,10 @@ class AuthenticationTests(APITestCase):
         """
         user = User.objects.get(username='olivia')
         view = ArticleDetail.as_view()
-        url = reverse('articles:article_detail', kwargs={"pk": 76})
+        url = reverse('articles:article_detail', kwargs={"slug": "not-found"})
         request = self.request_factory.delete(url)
         force_authenticate(request, user=user)
-        response = view(request, pk=76)
+        response = view(request, slug="not-found")
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
     def test_update_non_existent(self):
@@ -75,10 +75,10 @@ class AuthenticationTests(APITestCase):
         """
         user = User.objects.get(username='olivia')
         view = ArticleDetail.as_view()
-        url = reverse('articles:article_detail', kwargs={"pk": 76})
+        url = reverse('articles:article_detail', kwargs={"slug": "not-found"})
         request = self.request_factory.put(url, self.data)
         force_authenticate(request, user=user)
-        response = view(request, pk=76)
+        response = view(request, slug="not-found")
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
     def test_update_article_successful(self):
@@ -91,11 +91,11 @@ class AuthenticationTests(APITestCase):
         create_request = self.request_factory.post(self.articles_url, self.data)
         force_authenticate(create_request, user=user)
         create_response = list_view(create_request)
-        pk = create_response.data['id']
-        url = reverse('articles:article_detail', kwargs={"pk": pk})
+        slug = create_response.data['slug']
+        url = reverse('articles:article_detail', kwargs={"slug": slug})
         update_request = self.request_factory.put(url, self.data)
         force_authenticate(update_request, user=user)
-        update_response = detail_view(update_request, pk=pk)
+        update_response = detail_view(update_request, slug=slug)
         self.assertEqual(update_response.status_code, status.HTTP_200_OK)
 
     def test_delete_article_successful(self):
@@ -108,10 +108,10 @@ class AuthenticationTests(APITestCase):
         create_request = self.request_factory.post(self.articles_url, self.data)
         force_authenticate(create_request, user=user)
         create_response = list_view(create_request)
-        pk = create_response.data['id']
-        url = reverse('articles:article_detail', kwargs={"pk": pk})
+        slug = create_response.data['slug']
+        url = reverse('articles:article_detail', kwargs={"slug": slug})
         update_request = self.request_factory.delete(url)
         force_authenticate(update_request, user=user)
-        update_response = detail_view(update_request, pk=pk)
+        update_response = detail_view(update_request, slug=slug)
         self.assertEqual(update_response.status_code, status.HTTP_204_NO_CONTENT)
 

--- a/authors/apps/articles/urls.py
+++ b/authors/apps/articles/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls import url
+from django.urls import path
 from rest_framework.urlpatterns import format_suffix_patterns
 
 from . import views
@@ -6,8 +6,8 @@ from . import views
 app_name = "articles"
 
 urlpatterns = [
-    url(r'^$', views.ArticleList.as_view(), name='all_articles'),
-    url(r'^(?P<pk>[0-9]+)/$', views.ArticleDetail.as_view(), name='article_detail'),
+    path('', views.ArticleList.as_view(), name='all_articles'),
+    path('<str:slug>/', views.ArticleDetail.as_view(), name='article_detail'),
 ]
 
 urlpatterns = format_suffix_patterns(urlpatterns)

--- a/authors/apps/articles/views.py
+++ b/authors/apps/articles/views.py
@@ -1,4 +1,5 @@
 from django.utils.text import slugify
+import uuid
 from rest_framework import generics
 from rest_framework.permissions import IsAuthenticatedOrReadOnly
 
@@ -14,7 +15,8 @@ class ArticleList(generics.ListCreateAPIView):
     def get_serializer_context(self):
         context = super(ArticleList, self).get_serializer_context()
         author = context["request"].user.pk
-        slug = slugify(context["request"].data.get("title", "No Title"))
+        slug_text = context["request"].data.get("title", "No Title") + " " + uuid.uuid4().hex
+        slug = slugify(slug_text)
         context["request"].data.update({
             "author": author,
             "slug": slug
@@ -26,11 +28,13 @@ class ArticleDetail(generics.RetrieveUpdateDestroyAPIView):
     queryset = Article.objects.all()
     serializer_class = ArticleSerializer
     permission_classes = (IsAuthenticatedOrReadOnly,)
+    lookup_field = 'slug'
 
     def get_serializer_context(self):
         context = super(ArticleDetail, self).get_serializer_context()
         author = context["request"].user.pk
-        slug = slugify(context["request"].data.get("title", "No Title"))
+        slug_text = context["request"].data.get("title", "No Title") + " " + uuid.uuid4().hex
+        slug = slugify(slug_text)
         context["request"].data.update({
             "author": author,
             "slug": slug


### PR DESCRIPTION
**What does this PR do?**
Ensures slug is unique and can be used in the URL to search for a single article

**Description of Task to be completed?**
- Generate a unique slug from an article title.
- Enable slug to be used in the URL for searching

**How should this be manually tested?**
- Clone the repository from [here](https://github.com/andela/ah-scorpion) and check out the branch `fix-159620120-Fix-slug-uniqueness`
- Activate your virtual environment and use the `.env-sample` to set the environment variables.
- Use postman to test these endpoints.
  `POST api/v1/articles/` for creating an article 
  `GET api/v1/articles/<str:slug>/`  for getting the details of a single article

What are the relevant pivotal tracker stories?
[#159620120](https://www.pivotaltracker.com/n/projects/2184741/stories/159620120)