### PR TITLE
#160052316 Fix the issues listed on comments and articles endpoints

### DIFF
--- a/authors/apps/articles/serializers.py
+++ b/authors/apps/articles/serializers.py
@@ -5,10 +5,10 @@ from ..authentication.serializers import UserSerializer
 
 
 class ArticleSerializer(serializers.ModelSerializer):
-    title = serializers.CharField(
-        required=True,
-        max_length=100,
-    )
+    # title = serializers.CharField(
+    #     required=True,
+    #     max_length=100,
+    # )
     author = UserSerializer(read_only=True)
 
     likes = serializers.SerializerMethodField(method_name='get_likes_count')

--- a/authors/apps/articles/tests/test_views.py
+++ b/authors/apps/articles/tests/test_views.py
@@ -69,6 +69,7 @@ class ArticleTests(APITestCase):
         force_authenticate(request, user=user)
         response = view(request, slug="not-found")
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+        self.assertEqual(response.data["detail"], "Not found.")
 
     def test_update_non_existent(self):
         """
@@ -81,6 +82,7 @@ class ArticleTests(APITestCase):
         force_authenticate(request, user=user)
         response = view(request, slug="not-found")
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+        self.assertEqual(response.data["detail"], "Not found.")
 
     def test_update_article_successful(self):
         """

--- a/authors/apps/articles/views.py
+++ b/authors/apps/articles/views.py
@@ -11,6 +11,7 @@ from rest_framework.permissions import IsAuthenticatedOrReadOnly, \
     IsAuthenticated
 from rest_framework.response import Response
 
+
 from .models import Article
 from .serializers import ArticleSerializer
 
@@ -59,7 +60,7 @@ class ArticleList(generics.ListCreateAPIView):
         if not request:
             return context
         slug_text = context["request"].data.get(
-            "title", "No Title") + " " + uuid.uuid4().hex
+            "title", "") + " " + uuid.uuid4().hex
         slug = slugify(slug_text)
         context["request"].data.update({"slug": slug})
         return context
@@ -77,13 +78,12 @@ class ArticleDetail(generics.RetrieveUpdateDestroyAPIView):
             url_slug = self.kwargs['slug']
         except Exception:
             raise NotFound('Please check your url')
-        if context["request"].data.get(
-                "title",
-                "No Title") == Article.objects.get(slug=url_slug).title:
+        request_title = context["request"].data.get("title", "")
+        if request_title == Article.objects.get(slug=url_slug).title or \
+                request_title == "":
             slug = url_slug
         else:
-            slug_text = context["request"].data.get(
-                "title", "No Title") + " " + uuid.uuid4().hex
+            slug_text = request_title + " " + uuid.uuid4().hex
             slug = slugify(slug_text)
         context["request"].data.update({"slug": slug})
         return context

--- a/authors/apps/authentication/serializers.py
+++ b/authors/apps/authentication/serializers.py
@@ -17,17 +17,6 @@ def password_validator(password):
     if not bool(password_pattern.match(password)):
         raise serializers.ValidationError(
             "Password invalid. Password must be 8 characters long, "
-            "include numbers and letters and have no spaces"
-        )
-    return password
-
-
-def password_validator(password):
-    password_pattern = re.compile(r"(?=^.{8,80}$)(?=.*\d)"
-                                  r"(?=.*[a-z])(?!.*\s).*$")
-    if not bool(password_pattern.match(password)):
-        raise serializers.ValidationError(
-            "Password invalid. Password must be 8 characters long, "
             "include numbers and letters and have no spaces")
     return password
 
@@ -68,7 +57,7 @@ class RegistrationSerializer(serializers.ModelSerializer):
         model = User
         # List all of the fields that could possibly be included in a request
         # or response, including fields specified explicitly above.
-        fields = ['email', 'username', 'password']
+        fields = ['email', 'username', 'password', 'bio', 'image']
 
     def create(self, validated_data):
         # Use the `create_user` method we wrote earlier to create a new user.
@@ -222,7 +211,7 @@ class ForgotPasswordSerializers(serializers.Serializer):
             template='reset_password.html',
             content={
                 'user': data.get("email", None),
-                'domain': RESET_DOMAIN,
+                'domain': get_current_site(self.context['request']).domain,
                 'token': token,
             })
         email.send()

--- a/authors/apps/comments/tests/test_views.py
+++ b/authors/apps/comments/tests/test_views.py
@@ -123,6 +123,7 @@ class CommentsTests(APITestCase):
         force_authenticate(request, user=self.user)
         response = comment_view(request, slug='not')
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+        self.assertEqual(response.data["detail"], "Not found.")
 
     def test_get_comments_successful(self):
         """Test that a user can get comments successfully."""

--- a/authors/apps/comments/tests/test_views.py
+++ b/authors/apps/comments/tests/test_views.py
@@ -122,7 +122,7 @@ class CommentsTests(APITestCase):
         request = self.request_factory.get(url)
         force_authenticate(request, user=self.user)
         response = comment_view(request, slug='not')
-        self.assertEqual(response.data, [])
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
     def test_get_comments_successful(self):
         """Test that a user can get comments successfully."""

--- a/authors/apps/comments/tests/test_views.py
+++ b/authors/apps/comments/tests/test_views.py
@@ -104,6 +104,8 @@ class CommentsTests(APITestCase):
         force_authenticate(request, user=self.user)
         response = comment_view(request, slug=self.slug, pk="5463")
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+        self.assertEqual(response.data["detail"],
+                         "A comment with this ID does not exist.")
 
     def test_comment_without_article(self):
         """Test that a user can't comment on a non-existent article."""
@@ -114,6 +116,7 @@ class CommentsTests(APITestCase):
         force_authenticate(request, user=self.user)
         response = comment_view(request, slug='1234what')
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+        self.assertEqual(response.data["detail"], "Not found.")
 
     def test_get_comment_from_article_without_comment(self):
         """Test that a user can't get comment an article without comment."""
@@ -149,6 +152,8 @@ class CommentsTests(APITestCase):
         force_authenticate(request, user=self.user)
         response = comment_view(request, slug=self.slug, pk="5463")
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+        self.assertEqual(response.data["detail"],
+                         "A comment with this ID does not exist.")
 
     def test_delete_comment_successful(self):
         """Test that a user can delete comment."""
@@ -290,6 +295,8 @@ class LikeDislikeTests(APITestCase):
         force_authenticate(request, user=self.user)
         response = view(request, slug=self.slug, pk=20777)
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+        self.assertEqual(response.data["detail"],
+                         "A comment with this ID does not exist.")
 
     def test_dislike_unexisting_comment(self):
         """Test disliking a comment that does not exist."""
@@ -299,3 +306,5 @@ class LikeDislikeTests(APITestCase):
         force_authenticate(request, user=self.user)
         response = view(request, slug=self.slug, pk=10)
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+        self.assertEqual(response.data["detail"],
+                         "A comment with this ID does not exist.")

--- a/authors/apps/comments/views.py
+++ b/authors/apps/comments/views.py
@@ -65,7 +65,7 @@ class CommentsCreateDeleteAPIView(generics.RetrieveUpdateDestroyAPIView,
         try:
             comment = Comment.objects.get(pk=pk)
         except Exception:
-            raise NotFound('A comment with this id does not exist.')
+            raise NotFound('A comment with this ID does not exist.')
 
         comment.delete()
 
@@ -153,7 +153,7 @@ class LikeComment(generics.UpdateAPIView):
         try:
             comment = Comment.objects.get(pk=pk)
         except Comment.DoesNotExist:
-            raise NotFound('A comment with this id does not exist.')
+            raise NotFound('A comment with this ID does not exist.')
 
         # removes the user from the list of disliking users,
         # nothing changes if the user does not exist in
@@ -194,7 +194,7 @@ class DislikeComment(generics.UpdateAPIView):
         try:
             comment = Comment.objects.get(pk=pk)
         except Comment.DoesNotExist:
-            raise NotFound('A comment with this id does not exist.')
+            raise NotFound('A comment with this ID does not exist.')
 
         # removes the user from the list of liking users,
         # nothing changes if the user does not exist

--- a/authors/apps/comments/views.py
+++ b/authors/apps/comments/views.py
@@ -1,3 +1,5 @@
+from django.shortcuts import get_object_or_404
+
 from rest_framework import generics
 from rest_framework import status
 from rest_framework.exceptions import NotFound
@@ -6,6 +8,7 @@ from rest_framework.response import Response
 
 from ..comments.models import Comment, CommentHistory
 from ..comments.serializers import CommentSerializer, CommentHistorySerializer
+from ..articles.models import Article
 
 
 class CommentsListCreateAPIView(generics.ListCreateAPIView):
@@ -32,6 +35,7 @@ class CommentsListCreateAPIView(generics.ListCreateAPIView):
             slug = self.kwargs['slug']
         except Exception:
             raise NotFound('Please check your url, slug is missing')
+        get_object_or_404(Article, slug=slug)
         context = super(CommentsListCreateAPIView,
                         self).get_serializer_context()
         context["request"].data.update({


### PR DESCRIPTION
**What does this PR do?**
- Fix issues listed in the comment and articles backend

**Description of tasks completed**
- Fix bug that created a slug with "no title"
- Return 404 if an article with given slug does not exist instead of an empty list

**How can this PR be manually tested**
- `git pull` the source code from `bug-Fix-Issues-In-The-backend-160052316`
- Copy the variables from `sample.env` and put the correct parameters in `.env` file
- Run `source .env` on your terminal to export environmental variables and activate the virtual env
- Run `pip install -r requirements` to install the latest dependencies
- Run `python manage.py runserver` to start the project
- If not already done, create a new user account and login
- Create an article as shown in the previous instructions
- After creating an article and copy the slug
- Make a POST request to the following endpoint `api/v1/articles/<str: slug>/comments/` replacing the `<slug>` with the slug you copied above. The data should be a comment 
`{"content": "Sample comment"}`
- You should get the comment back. 
- Make a DELETE request to the following endpoint `api/v1/articles/<str: slug>/comments/<int: id>/` replacing the <id> with the id of the comment you got from the delete request you copied above. This returns 204_NO_CONTENT
- Make a GET request with the endpoint `api/v1/articles/<str: slug>/comments/` and view all the comments you have made to the article from which you have taken the slug.
- Make a PATCH request to `api/v1/articles/<str: slug>/` to edit an article even without a new title, the slug should be the same



**Relevant Stories**
[160052316](https://www.pivotaltracker.com/n/projects/2184741/stories/160052316)