### PR TITLE
#160232609 Add automatic redirection to front-end after user clicks verification link

### DIFF
--- a/.env-sample
+++ b/.env-sample
@@ -23,3 +23,6 @@ export SCORPION_FB_SECRET="facebook app id"
 
 # Debugging
 export SCORPION_DEBUG=True
+
+# Front-end hostname
+export SCORPION_FRONT_END_HOST="your front-end hostname eg.localhost:3000/"

--- a/authors/apps/authentication/account_activator.py
+++ b/authors/apps/authentication/account_activator.py
@@ -1,6 +1,5 @@
-from django.http import HttpResponse, HttpResponseRedirect
+from django.http import HttpResponse
 from django.shortcuts import redirect
-from django.urls import reverse
 from rest_framework.exceptions import AuthenticationFailed
 
 from authors.apps.authentication.backends import JWTAuthentication

--- a/authors/apps/authentication/account_activator.py
+++ b/authors/apps/authentication/account_activator.py
@@ -1,7 +1,10 @@
-from django.http import HttpResponse
+from django.http import HttpResponse, HttpResponseRedirect
+from django.shortcuts import redirect
+from django.urls import reverse
 from rest_framework.exceptions import AuthenticationFailed
 
 from authors.apps.authentication.backends import JWTAuthentication
+from authors.settings import FRONT_END_HOST_NAME
 
 
 def activate(request, token):
@@ -20,9 +23,10 @@ def activate(request, token):
 
         user.is_active = True
         user.save()
-        return HttpResponse(
-            'Thank you for confirming your email address. '
-            'Welcome to Authors\' Haven.')
+        front_end_host = FRONT_END_HOST_NAME
+        front_end_host = front_end_host + "/login"
+        return redirect(front_end_host)
+
     # User is not found
     else:
         return HttpResponse(status=401, content='Activation link is invalid!')

--- a/authors/apps/authentication/serializers.py
+++ b/authors/apps/authentication/serializers.py
@@ -16,7 +16,7 @@ def password_validator(password):
                                   r"(?=.*[a-z])(?!.*\s).*$")
     if not bool(password_pattern.match(password)):
         raise serializers.ValidationError(
-            "Password invalid, Password must be 8 characters long, "
+            "Password invalid. Password must be 8 characters long, "
             "include numbers and letters and have no spaces"
         )
     return password
@@ -27,7 +27,7 @@ def password_validator(password):
                                   r"(?=.*[a-z])(?!.*\s).*$")
     if not bool(password_pattern.match(password)):
         raise serializers.ValidationError(
-            "Password invalid, Password must be 8 characters long, "
+            "Password invalid. Password must be 8 characters long, "
             "include numbers and letters and have no spaces")
     return password
 

--- a/authors/apps/authentication/templates/reset_password.html
+++ b/authors/apps/authentication/templates/reset_password.html
@@ -420,6 +420,13 @@
                         <td class="email-body" width="100%" cellpadding="0" cellspacing="0">
                             <table class="email-body_inner" align="center" width="570" cellpadding="0" cellspacing="0">
                                 <!-- Body content -->
+                                <img src="http://res.cloudinary
+.com/dqvk8ugtp/image/upload/v1535993624/Author_sHaven_logo_sxca8t.png"
+                                     alt="Authors Haven Logo" style="
+    width: 100px;
+    margin-left: 44%;
+    margin-right:  auto;
+"/>
                                 <tr>
                                     <td class="content-cell">
                                         <p>You recently requested to reset your password for your account. Use the button below
@@ -437,7 +444,12 @@
                                                                 <table border="0" cellspacing="0" cellpadding="0">
                                                                     <tr>
                                                                         <td>
-                                                                            <a href=http://{{ domain }}{% url 'authentication:password_reset_done' token=token %} class="button button--blue" target="_blank">Reset your password</a>
+                                                                            <a href=
+                                                                                       {{ domain }}{% url 'authentication:password_reset_done' token=token %} class="button"
+                                                                               style="color: white;"
+                                                                               target="_blank">Reset
+                                                                                your
+                                                                                password</a>
                                                                         </td>
                                                                     </tr>
                                                                 </table>
@@ -455,8 +467,9 @@
                                                 <td>
                                                     <p class="sub">If you’re having trouble with the button above, copy and paste the URL
                                                         below into your web browser.</p>
-                                                    <a class="sub" href=http://{{ domain }}{% url 'authentication:password_reset_done' token=token %}>
-                                                        http://{{ domain }}{% url 'authentication:password_reset_done' token=token %}
+                                                    <a class="sub" href=
+                                                            {{ domain }}{% url 'authentication:password_reset_done' token=token %}>
+                                                        {{ domain }}{% url 'authentication:password_reset_done' token=token %}
 
                                                     </a>
                                                 </td>

--- a/authors/apps/authentication/tests/test_user_verification.py
+++ b/authors/apps/authentication/tests/test_user_verification.py
@@ -4,6 +4,7 @@ from django.urls import reverse
 from rest_framework import status
 from rest_framework.test import APITestCase
 
+from authors import settings
 from authors.apps.core.token import generate_token
 
 
@@ -67,9 +68,10 @@ class AuthenticationTests(APITestCase):
 
         self.activate_url = reverse(self.activate_url, kwargs={'token': token})
         response = self.client.get(self.activate_url)
-        assert ("Thank you for confirming your email address" in str(
-            response._container))
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        assert (settings.FRONT_END_HOST_NAME+"/login" in str(
+            response._headers['location']))
+        self.assertEqual(response.status_code, status.HTTP_302_FOUND)
 
     def test_used_token(self):
         """

--- a/authors/apps/authentication/tests/test_views.py
+++ b/authors/apps/authentication/tests/test_views.py
@@ -62,7 +62,7 @@ class AuthenticationTests(APITestCase):
         response = self.client.post(self.reg_url, self.data, format='json')
         self.assertEqual(
             response.data['errors']['password'][0],
-            "Password invalid, Password must be 8 characters long,"
+            "Password invalid. Password must be 8 characters long,"
             " include numbers and letters and have no spaces")
 
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)

--- a/authors/settings.py
+++ b/authors/settings.py
@@ -187,6 +187,7 @@ CORS_ORIGIN_WHITELIST = (
     '0.0.0.0:4000',
     'localhost:4000',
     'localhost:3000',
+    'https://authors-haven-dev.herokuapp.com/'
 )
 
 # Tell Django about the custom `User` model we created. The string
@@ -232,4 +233,6 @@ SOCIAL_AUTH_GOOGLE_OAUTH2_SCOPE = ['email', 'username']
 SOCIAL_AUTH_GOOGLE_OAUTH2_KEY = os.environ["SCORPION_GOOGLE_KEY"]
 SOCIAL_AUTH_GOOGLE_OAUTH2_SECRET = os.environ["SCORPION_GOOGLE_SECRET"]
 
-RESET_DOMAIN = 'localhost:3000'
+FRONT_END_HOST_NAME = os.environ["SCORPION_FRONT_END_HOST"]
+
+RESET_DOMAIN = os.environ["SCORPION_FRONT_END_HOST"]

--- a/authors/settings.py
+++ b/authors/settings.py
@@ -188,6 +188,7 @@ CORS_ORIGIN_WHITELIST = (
     'localhost:4000',
     'localhost:3000',
     'https://authors-haven-dev.herokuapp.com/'
+    'https://authors-haven-frontend.herokuapp.com/'
 )
 
 # Tell Django about the custom `User` model we created. The string


### PR DESCRIPTION
#### What does this PR do?
- adds an option to redirect the user to the login page upon clicking the user registration verification link

#### Description of tasks completed
- added env variable to set the front-end hostname
- changed the activate account method to redirect to the login page after account activation.
- updated the `env sample` file for the new required key
- updated tests

####  How can this PR be manually tested?
- use git to pull from the branch `ch-front-end-redirect-160232609`
-  update the `.env` file and add the hostame for your react app. **Note:** if you are. using `localhost`, you must include the `http://`
- export env variables by running `source .env`
- run `python manage.py runserver` to start your local server
- using postman create a new user by making a `POST` request and including the following json request
```
{
"username": "your user name",
"email": "your email address",
"password": "your strong password"
}
```
- an activation link will be sent to the email address provided
- if not running, start the `React` app server specified in the .env variable above.
- click on the activation link sent to your email
- you should be redirected to the react login page with the favicon for your React app (If this page does not exist, a blank page will be displayed)

#### What are the related PT stories
- [#160232609](https://www.pivotaltracker.com/story/show/160232609)