### PR TITLE
#160474322 unfavourating using POST request

### DIFF
--- a/authors/apps/articles/models.py
+++ b/authors/apps/articles/models.py
@@ -24,9 +24,6 @@ class Article(models.Model):
     author = models.ForeignKey(User, on_delete=models.CASCADE,
                                db_column='author')
 
-    favorited = models.ManyToManyField(User, related_name='favorited',
-                                       blank=True)
-
     likes = models.ManyToManyField(User, related_name='likes', blank=True)
     dislikes = models.ManyToManyField(
         User, related_name='dislikes', blank=True)

--- a/authors/apps/articles/serializers.py
+++ b/authors/apps/articles/serializers.py
@@ -15,7 +15,6 @@ class ArticleSerializer(serializers.ModelSerializer):
     dislikes = serializers.SerializerMethodField(
         method_name='get_dislikes_count')
 
-
     class Meta:
         model = Article
         fields = '__all__'
@@ -53,7 +52,7 @@ class ArticleSerializer(serializers.ModelSerializer):
             return None
         else:
             weighted_total = (5 * fives) + (4 * fours) + (3 * threes) + (
-                        2 * twos) + (1 * ones)
+                    2 * twos) + (1 * ones)
             weighted_average = weighted_total / all_ratings
             return round(weighted_average, 2)
 

--- a/authors/apps/articles/serializers.py
+++ b/authors/apps/articles/serializers.py
@@ -14,8 +14,7 @@ class ArticleSerializer(serializers.ModelSerializer):
     likes = serializers.SerializerMethodField(method_name='get_likes_count')
     dislikes = serializers.SerializerMethodField(
         method_name='get_dislikes_count')
-    # favorited = serializers.SerializerMethodField(
-    #     method_name='get_favorite_count')
+
 
     class Meta:
         model = Article
@@ -86,5 +85,4 @@ class ArticleSerializer(serializers.ModelSerializer):
         Gets the number of times that a particular article has been
         favourited
         """
-        print("HJBJHASBDHJBDJBJ", instance.favorited)
-        return instance.favorited
+        return instance.favorited.count()

--- a/authors/apps/articles/serializers.py
+++ b/authors/apps/articles/serializers.py
@@ -14,8 +14,8 @@ class ArticleSerializer(serializers.ModelSerializer):
     likes = serializers.SerializerMethodField(method_name='get_likes_count')
     dislikes = serializers.SerializerMethodField(
         method_name='get_dislikes_count')
-    favorited = serializers.SerializerMethodField(
-        method_name='get_favorite_count')
+    # favorited = serializers.SerializerMethodField(
+    #     method_name='get_favorite_count')
 
     class Meta:
         model = Article
@@ -86,4 +86,5 @@ class ArticleSerializer(serializers.ModelSerializer):
         Gets the number of times that a particular article has been
         favourited
         """
-        return instance.favorited.count()
+        print("HJBJHASBDHJBDJBJ", instance.favorited)
+        return instance.favorited

--- a/authors/apps/articles/tests/test_favorite.py
+++ b/authors/apps/articles/tests/test_favorite.py
@@ -86,8 +86,8 @@ class AuthenticationTests(APITestCase):
 
         self.assertEqual(response.status_code,
                          status.HTTP_200_OK)
-        assert ("You have already marked this article as a favourite" in
-                str(response.data))
+        assert ("'title': 'Be a python coder in three weeks without a "
+                "hassle'" and "'favorited': 0" in str(response.data))
 
     def test_un_favourite(self):
         user = User.objects.get(email="musamo@live.com")

--- a/authors/apps/articles/tests/test_favorite.py
+++ b/authors/apps/articles/tests/test_favorite.py
@@ -75,19 +75,19 @@ class AuthenticationTests(APITestCase):
 
         response = view(request, slug)
 
-        assert ("'title': 'Be a python coder in three weeks without a "
-                "hassle'" and "'favorited': 1" in str(response.data))
+        assert (user.email in str(
+            str(response.data['article']['favoriting_users'])))
         self.assertEqual(response.status_code,
                          status.HTTP_200_OK)
 
-        # Test trying to favourite again
+        # Test trying to favourite again (unfavorites)
         force_authenticate(request, user=user)
         response = view(request, slug)
 
         self.assertEqual(response.status_code,
                          status.HTTP_200_OK)
-        assert ("'title': 'Be a python coder in three weeks without a "
-                "hassle'" and "'favorited': 0" in str(response.data))
+        assert ('favoriting_users' not in str(
+            response.data['article']))
 
     def test_un_favourite(self):
         user = User.objects.get(email="musamo@live.com")
@@ -132,7 +132,7 @@ class AuthenticationTests(APITestCase):
         force_authenticate(request, user=user)
         response = view(request, slug)
 
-        assert ("'title': 'Be a python coder in three weeks without a "
-                "hassle'" and "'favorited': 0" in str(response.data))
+        assert ('favoriting_users' not in str(
+            response.data['article']))
         self.assertEqual(response.status_code,
                          status.HTTP_200_OK)

--- a/authors/apps/articles/views.py
+++ b/authors/apps/articles/views.py
@@ -49,9 +49,9 @@ class ArticleFilter(filters.FilterSet):
 class ArticleList(generics.ListCreateAPIView):
     queryset = Article.objects.all()
     serializer_class = ArticleSerializer
-    permission_classes = (IsAuthenticatedOrReadOnly, )
+    permission_classes = (IsAuthenticatedOrReadOnly,)
     pagination_class = LimitOffsetPagination
-    filter_backends = (filters.DjangoFilterBackend, )
+    filter_backends = (filters.DjangoFilterBackend,)
     filterset_class = ArticleFilter
 
     def get_serializer_context(self):
@@ -69,7 +69,7 @@ class ArticleList(generics.ListCreateAPIView):
 class ArticleDetail(generics.RetrieveUpdateDestroyAPIView):
     queryset = Article.objects.all()
     serializer_class = ArticleSerializer
-    permission_classes = (IsAuthenticatedOrReadOnly, )
+    permission_classes = (IsAuthenticatedOrReadOnly,)
     lookup_field = 'slug'
 
     def get_serializer_context(self):
@@ -99,7 +99,7 @@ class LikeArticle(generics.UpdateAPIView):
     """
     queryset = Article.objects.all()
     serializer_class = ArticleSerializer
-    permission_classes = (IsAuthenticatedOrReadOnly, )
+    permission_classes = (IsAuthenticatedOrReadOnly,)
 
     def update(self, request, slug):
         """Update the user's liking status on a particular article."""
@@ -139,7 +139,7 @@ class DislikeArticle(generics.UpdateAPIView):
     """
     queryset = Article.objects.all()
     serializer_class = ArticleSerializer
-    permission_classes = (IsAuthenticatedOrReadOnly, )
+    permission_classes = (IsAuthenticatedOrReadOnly,)
 
     def update(self, request, slug):
         """Update the user's disliking status on a particular article."""
@@ -179,7 +179,7 @@ class FavoriteArticle(generics.ListCreateAPIView, generics.DestroyAPIView):
     Else: The use no longer favourites the article
     """
 
-    permission_classes = (IsAuthenticated, )
+    permission_classes = (IsAuthenticated,)
     queryset = Article.objects.all()
     serializer_class = ArticleSerializer
 
@@ -224,7 +224,7 @@ class FavoriteArticle(generics.ListCreateAPIView, generics.DestroyAPIView):
                 favorited_users.append(username)
 
             output = serializer.data
-            output['favoriting_users']= favorited_users
+            output['favoriting_users'] = favorited_users
             response = {"article": output}
             return Response(response, status=status.HTTP_200_OK)
 

--- a/authors/apps/articles/views.py
+++ b/authors/apps/articles/views.py
@@ -202,12 +202,13 @@ class FavoriteArticle(generics.ListCreateAPIView, generics.DestroyAPIView):
         user = request.user
 
         if user in article.favorited.all():
-            # Returns a message that the user has already favourited article
+            # Remove the user from the list of the ones that have favourited
+            #  article
 
-            response = {
-                "message": "You have already marked "
-                "this article as a favourite"
-            }
+            article.favorited.remove(user.id)
+
+            serializer = self.get_serializer(article)
+            response = {"article": serializer.data}
             return Response(response, status=status.HTTP_200_OK)
 
         else:

--- a/authors/apps/articles/views.py
+++ b/authors/apps/articles/views.py
@@ -11,6 +11,7 @@ from rest_framework.permissions import IsAuthenticatedOrReadOnly, \
     IsAuthenticated
 from rest_framework.response import Response
 
+from authors.apps.authentication.models import User
 from .models import Article
 from .serializers import ArticleSerializer
 
@@ -216,7 +217,15 @@ class FavoriteArticle(generics.ListCreateAPIView, generics.DestroyAPIView):
             article.favorited.add(user.id)
 
             serializer = self.get_serializer(article)
-            response = {"article": serializer.data}
+
+            favorited_users = []
+            for user_id in serializer.data['favorited']:
+                username = User.objects.get(id=user_id).email
+                favorited_users.append(username)
+
+            output = serializer.data
+            output['favoriting_users']= favorited_users
+            response = {"article": output}
             return Response(response, status=status.HTTP_200_OK)
 
     def delete(self, request, slug):

--- a/authors/apps/authentication/tests/test_user_verification.py
+++ b/authors/apps/authentication/tests/test_user_verification.py
@@ -69,6 +69,8 @@ class AuthenticationTests(APITestCase):
         self.activate_url = reverse(self.activate_url, kwargs={'token': token})
         response = self.client.get(self.activate_url)
 
+        print(response._headers)
+
         assert (settings.FRONT_END_HOST_NAME+"/login" in str(
             response._headers['location']))
         self.assertEqual(response.status_code, status.HTTP_302_FOUND)


### PR DESCRIPTION
#### What does this PR do?
- Enables unfavouriting an already favourited article by sending a `POST` request

#### Description of tasks done
- added code lines to remove the user from users who have favourited an article when a `POST` request is made
- Modified tests to pass

#### How can this PR be manually tested?
Prerequisite: Postman
- use `git pull` to get the source code from `ch-article-unfavouriting-160474322` branch
- use `source .env` to export environmental variables and activate virtual env
- run `python manage.py runserver` to start  the project
- if not already done, create a new user account and login
- if not already done, create an article and copy the `slug`
- create a `POST` request to the following endpoint `<str:slug>/favorite/` replacing the `<slug>` with the slug you copied above
- you should get the article back. Notice that the key `favoriting_users` has your email address
- create another `POST` request to the following endpoint `<str:slug>/favorite/` replacing the `<slug>` with the slug you copied above
- you should get the article back. Notice that the key `favoriting_users` is not available and if available, does not have your email address 

#### What are the related PR Stories?
- [#160474322](https://www.pivotaltracker.com/story/show/160474322)