### PR TITLE
#160474322 Add Favorited, Likes and Dislikes Fields in UserSerializer

### DIFF
--- a/authors/apps/authentication/serializers.py
+++ b/authors/apps/authentication/serializers.py
@@ -160,7 +160,8 @@ class UserSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = User
-        fields = ('email', 'username', 'password', 'bio', 'image')
+        fields = ('email', 'username', 'password', 'bio', 'image',
+                  'favorited')
 
         # The `read_only_fields` option is an alternative for explicitly
         # specifying the field with `read_only=True` like we did for password

--- a/authors/apps/authentication/tests/test_user_verification.py
+++ b/authors/apps/authentication/tests/test_user_verification.py
@@ -69,8 +69,6 @@ class AuthenticationTests(APITestCase):
         self.activate_url = reverse(self.activate_url, kwargs={'token': token})
         response = self.client.get(self.activate_url)
 
-        print(response._headers)
-
         assert (settings.FRONT_END_HOST_NAME+"/login" in str(
             response._headers['location']))
         self.assertEqual(response.status_code, status.HTTP_302_FOUND)


### PR DESCRIPTION
#### What does this PR do?
- adds a list of articles liked, disliked and favourited to user serializer.

#### Description of tasks completed
- added the `favorited`, `likes` and `dislikes` fields in the `UserSerializer`

#### How can this PR be manually tested
- use git to pull from the branch `ch-article-unfavouriting-160474322`
- ensure that your environment variables are updated on the `.env` file
- run `source .env` to export your env variables
- run `python manage.py runserver` to start the server
- login using any user in the system
- you should receive the user back with the `json` keys for `favorited`, `likes` and `dislikes`

#### Any background information?
- in the front-end, when a user opens an article, we need to know if they have already liked, disliked or favourited the article and update the UI to show these statuses.
- this info can be got by calling the `/api/v1/user/` in the API which returns the details as implemented in this PR

#### What are the related PT Stories?
- [#160474322](https://www.pivotaltracker.com/story/show/160474322)